### PR TITLE
Github Theme - Improve text sizing

### DIFF
--- a/Github/github.css
+++ b/Github/github.css
@@ -105,6 +105,10 @@ body h6{
   font-size:1em
 }
 
+body p{
+  font-size:12pt;
+}
+
 body p,body blockquote,body ul,body ol,body dl,body table,body pre{
   margin:15px 0
 }
@@ -112,6 +116,10 @@ body p,body blockquote,body ul,body ol,body dl,body table,body pre{
 body h1 tt,body h1 code,body h2 tt,body h2 code,body h3 tt,body h3 code,body h4 tt,body h4 code,body h5 tt,body h5 code,body h6 tt,body h6 code
 {
   font-size:inherit;
+}
+
+body li{
+  font-size:12pt;
 }
 
 body li p.first

--- a/Github/github.css
+++ b/Github/github.css
@@ -1,6 +1,8 @@
+# ~/.config/ReText project/github.css
+
 body
 {
-    font-size:15px;
+    font-size:12pt;
     line-height:1.7;
     overflow-x:hidden;
 
@@ -141,7 +143,7 @@ body dl
 
 body dl dt
 {
-  font-size:14px;
+  font-size:12pt;
   font-style:italic;
   font-weight:700;
   margin-top:15px;
@@ -321,7 +323,7 @@ body code
 
 code,pre{
   font-family:Consolas, "Liberation Mono", Courier, monospace;
-  font-size:12px
+  font-size:11pt;
 }
 
 body pre>code
@@ -337,7 +339,7 @@ body .highlight pre,body pre
 {
   background-color:#f8f8f8;
   border:1px solid #ddd;
-  font-size:13px;
+  font-size:11pt;
   line-height:19px;
   overflow:auto;
   padding:6px 10px;


### PR DESCRIPTION
Hello there and thank you for making this theme! I've just started using it today and noticed the text inside ```<p>``` and ```<li>``` are a bit small compared to heading text. I added a couple rules to try and address that.

Whether you accept this or not, thanks for making this theme. I'm really happy to have found it!